### PR TITLE
v0.3.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# v0.3.1
+
+## Changes
+
+- Comma dangle is require for Flow inexact object notation (trailing ...) when multiline.
+
 # v0.3.0
 
 ## Changes

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-config-nugit",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "description": "Nugit's JS ESLint config, following our styleguide",
   "main": "index.js",
   "scripts": {
@@ -8,7 +8,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/ugit/eslint-config-nugit"
+    "url": "https://github.com/nugit/eslint-config-nugit"
   },
   "keywords": [
     "eslint",

--- a/rules/flow.js
+++ b/rules/flow.js
@@ -12,7 +12,7 @@ module.exports = {
     'flowtype/array-style-simple-type': ['error', 'shorthand'],
     'flowtype/boolean-style': ['error', 'boolean'],
     'flowtype/define-flow-type': 'warn',
-    'flowtype/delimiter-dangle': ['error', 'always-multiline', 'always-multiline'],
+    'flowtype/delimiter-dangle': ['error', 'always-multiline', 'always-multiline', 'always-multiline'],
     'flowtype/generic-spacing': ['error', 'never'],
     'flowtype/newline-after-flow-annotation': ['error', 'always'],
     'flowtype/object-type-delimiter': ['error', 'comma'],


### PR DESCRIPTION
## Changes

- Comma dangle is require for Flow inexact object notation (trailing ...) when multiline

